### PR TITLE
GCC 10 and Bison 3.7 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@ canonluj.inc
 cmafihe
 cm_scan.c
 dfasyn/dfasyn
-dfasyn/parse.c
-dfasyn/parse.h
+dfasyn/parse.tab.c
+dfasyn/parse.tab.h
 dfasyn/scan.c
 dictdata.c
 elitabs.c
@@ -24,6 +24,7 @@ nonterm.h
 *.o
 *.output
 rpc2x_act.y
+rpc2x_act.tab.*
 rpc2x_full_*.y
 rpc2x_nc.y
 rpc_full.c

--- a/Makefile.in
+++ b/Makefile.in
@@ -20,7 +20,7 @@ CMAFIHE_LDOPTS=@@CMAFIHE_LDOPTS@@
 LANG=C
 
 CC=gcc
-CFLAGS= @@OPTDEBUG@@ @@DEFINES@@ -DDEFAULT_DICTIONARY=\"$(DICTIONARY)\"
+CFLAGS= -fcommon @@OPTDEBUG@@ @@DEFINES@@ -DDEFAULT_DICTIONARY=\"$(DICTIONARY)\"
 BISON=bison
 
 OBJS2 = main.o lex1.o lex2.o cmavotab.o rpc_tab.o functions.o \
@@ -62,9 +62,8 @@ rpc2x_nc.y : rpc2x.y uncom
 rpc2x_act.y nonterm.h nonterm.c : rpc2x_nc.y
 	perl ./action.perl < rpc2x_nc.y > rpc2x_act.y
 
-rpc2x_act.tab.c rpc2x_act.output rpc_tab.h : rpc2x_act.y
+rpc2x_act.tab.c rpc2x_act.output rpc2x_act.tab.h : rpc2x_act.y
 	$(BISON) -v -d rpc2x_act.y
-	mv rpc2x_act.tab.h rpc_tab.h
 
 rpc_tab.c : rpc2x_act.tab.c
 	perl add_trace_to_tabc.pl < rpc2x_act.tab.c > rpc_tab.c
@@ -200,7 +199,7 @@ canonluj.inc:
 
 clean:
 	-(cd dfasyn && make clean)
-	-rm *.output *.tab.c *_tab.c rpc_full.c *.o \
+	-rm -f *.output *.tab.[ch] *_tab.[ch] rpc_full.c *.o \
         jbofihe cmafihe smujajgau vlatai jvocuhadju \
         *.dict uncom.c uncom.o uncom \
         morf_lex.c morfvlex.c morf_enc.c morf*_dfa.c \
@@ -231,46 +230,46 @@ main.o: main.c nodes.h nonterm.h functions.h output.h version.h
 lex1.o: lex1.c cmavotab.h nodes.h nonterm.h functions.h output.h \
  lujvofns.h morf.h bccheck.h
 lex2.o: lex2.c functions.h nonterm.h nodes.h output.h cmavotab.h \
- rpc_tab.h elide.h
-cmavotab.o: cmavotab.c cmavotab.h rpc_tab.h
+ rpc2x_act.tab.h elide.h
+cmavotab.o: cmavotab.c cmavotab.h rpc2x_act.tab.h
 rpc_tab.o: rpc_tab.c nodes.h nonterm.h functions.h output.h
-functions.o: functions.c functions.h nonterm.h nodes.h output.h rpc_tab.h
-categ.o: categ.c nodes.h nonterm.h rpc_tab.h functions.h output.h \
+functions.o: functions.c functions.h nonterm.h nodes.h output.h rpc2x_act.tab.h
+categ.o: categ.c nodes.h nonterm.h rpc2x_act.tab.h functions.h output.h \
  stag_dfa.h
 nonterm.o: nonterm.c
 tree.o: tree.c nonterm.h functions.h nodes.h output.h cmavotab.h \
- rpc_tab.h
+ rpc2x_act.tab.h
 translate.o: translate.c functions.h nonterm.h nodes.h output.h \
  canonluj.h morf.h dictaccs.h
 latex.o: latex.c functions.h nonterm.h nodes.h output.h latex.h
 properties.o: properties.c nodes.h nonterm.h functions.h output.h
 conversion.o: conversion.c nodes.h nonterm.h functions.h output.h \
- rpc_tab.h cmavotab.h
-terms.o: terms.c functions.h nonterm.h nodes.h output.h rpc_tab.h \
+ rpc2x_act.tab.h cmavotab.h
+terms.o: terms.c functions.h nonterm.h nodes.h output.h rpc2x_act.tab.h \
  cmavotab.h
 memory.o: memory.c functions.h nonterm.h nodes.h output.h
-tenses.o: tenses.c rpc_tab.h nonterm.h functions.h nodes.h output.h
+tenses.o: tenses.c rpc2x_act.tab.h nonterm.h functions.h nodes.h output.h
 output.o: output.c nodes.h nonterm.h functions.h output.h cmavotab.h \
- rpc_tab.h
+ rpc2x_act.tab.h
 textout.o: textout.c functions.h nonterm.h nodes.h output.h
 htmlout.o: htmlout.c functions.h nonterm.h nodes.h output.h
-connect.o: connect.c nodes.h nonterm.h functions.h output.h rpc_tab.h \
+connect.o: connect.c nodes.h nonterm.h functions.h output.h rpc2x_act.tab.h \
  cmavotab.h
 latexblk.o: latexblk.c functions.h nonterm.h nodes.h output.h latex.h
-relative.o: relative.c nodes.h nonterm.h rpc_tab.h functions.h output.h \
+relative.o: relative.c nodes.h nonterm.h rpc2x_act.tab.h functions.h output.h \
  cmavotab.h
 textblk.o: textblk.c functions.h nonterm.h nodes.h output.h
 errorscan.o: errorscan.c functions.h nonterm.h nodes.h output.h
 canonluj.o: canonluj.c canonluj.h canonluj.inc
 lujvofns.o: lujvofns.c lujvofns.h
-erasure.o: erasure.c nodes.h nonterm.h rpc_tab.h functions.h output.h
+erasure.o: erasure.c nodes.h nonterm.h rpc2x_act.tab.h functions.h output.h
 rpc_full.o: rpc_full.c nodes.h nonterm.h functions.h output.h
 morf.o: morf.c morf.h morf_dfa.h bccheck.h morf_lex.c morfvlex.c
 morf_dfa.o: morf_dfa.c morf_dfa.h
 bccheck.o: bccheck.c bccheck.h bctables.c
 tracebk.o: tracebk.c functions.h nonterm.h nodes.h output.h trctabs.c \
  trcftabs.c
-elide.o: elide.c nodes.h nonterm.h rpc_tab.h cmavotab.h functions.h \
+elide.o: elide.c nodes.h nonterm.h rpc2x_act.tab.h cmavotab.h functions.h \
  output.h elide.h elitabs.c
 dictaccs.o: dictaccs.c functions.h nonterm.h nodes.h output.h canonluj.h \
  morf.h

--- a/categ.c
+++ b/categ.c
@@ -14,7 +14,7 @@
 #include <assert.h>
 #include <string.h>
 #include "nodes.h"
-#include "rpc_tab.h"
+#include "rpc2x_act.tab.h"
 #include "functions.h"
 #include "stag_dfa.h"
 

--- a/cmavotab.c
+++ b/cmavotab.c
@@ -8,7 +8,7 @@
 /* COPYRIGHT */
 
 #include "cmavotab.h"
-#include "rpc_tab.h"
+#include "rpc2x_act.tab.h"
 #define UNKNOWN 0
 
 CmavoCell cmavo_table[] = {

--- a/connect.c
+++ b/connect.c
@@ -17,7 +17,7 @@
 #include "nodes.h"
 #include "nonterm.h"
 #include "functions.h"
-#include "rpc_tab.h"
+#include "rpc2x_act.tab.h"
 #include "cmavotab.h"
 
 static char *truth_ex[] = {

--- a/conversion.c
+++ b/conversion.c
@@ -17,7 +17,7 @@
 #include <assert.h>
 #include "nodes.h"
 #include "functions.h"
-#include "rpc_tab.h"
+#include "rpc2x_act.tab.h"
 #include "cmavotab.h"
 
 /*++++++++++++++++++++++++++++++

--- a/dfasyn/Makefile
+++ b/dfasyn/Makefile
@@ -10,25 +10,23 @@ CC=gcc
 #CFLAGS=-g
 #CFLAGS=-O2 -pg
 CFLAGS=-O2
-OBJ = parse.o scan.o n2d.o expr.o tabcompr.o compdfa.o
+OBJ = parse.tab.o scan.o n2d.o expr.o tabcompr.o compdfa.o
 
 all : dfasyn
 
 dfasyn : $(OBJ)
 	$(CC) $(CFLAGS) -o dfasyn $(OBJ)
 
-parse.c parse.h : parse.y
+parse.tab.c parse.tab.h : parse.y
 	bison -v -d parse.y
-	mv parse.tab.c parse.c
-	mv parse.tab.h parse.h
 
-parse.o : parse.c n2d.h
+parse.tab.o : parse.tab.c n2d.h
 
 scan.c : scan.l
 	flex -t -s scan.l > scan.c
 
-scan.o : scan.c parse.h n2d.h
+scan.o : scan.c parse.tab.h n2d.h
 
 clean:
-	rm dfasyn *.o scan.c parse.c parse.h parse.output
+	rm -f dfasyn *.o scan.c parse.tab.c parse.tab.h parse.output
 

--- a/dfasyn/scan.l
+++ b/dfasyn/scan.l
@@ -10,7 +10,7 @@
 
 %{
 #include "n2d.h"
-#include "parse.h"
+#include "parse.tab.h"
 
 int lineno = 1;
 %}

--- a/elide.c
+++ b/elide.c
@@ -14,7 +14,7 @@
 
 #include <stdio.h>
 #include "nodes.h"
-#include "rpc_tab.h"
+#include "rpc2x_act.tab.h"
 #include "cmavotab.h"
 #include "functions.h"
 #include "elide.h"

--- a/elide.h
+++ b/elide.h
@@ -9,7 +9,7 @@
 #define ELIDE_H
 
 #include "nodes.h"
-#include "rpc_tab.h"
+#include "rpc2x_act.tab.h"
 
 typedef struct {
   int value;

--- a/erasure.c
+++ b/erasure.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include <assert.h>
 #include "nodes.h"
-#include "rpc_tab.h"
+#include "rpc2x_act.tab.h"
 #include "functions.h"
 
 /*++++++++++++++++++++++++++++++

--- a/functions.c
+++ b/functions.c
@@ -12,7 +12,7 @@
 #include <ctype.h>
 #include "functions.h"
 #include "nonterm.h"
-#include "rpc_tab.h"
+#include "rpc2x_act.tab.h"
 
 /* command line option */
 extern int insert_elidables;

--- a/lex2.c
+++ b/lex2.c
@@ -24,7 +24,7 @@
 
 #define YYSTYPE TreeNode *
 
-#include "rpc_tab.h"
+#include "rpc2x_act.tab.h"
 #include "elide.h"
 
 /* For signalling syntax errors back to main routine */

--- a/output.c
+++ b/output.c
@@ -14,7 +14,7 @@
 #include "nodes.h"
 #include "functions.h"
 #include "cmavotab.h"
-#include "rpc_tab.h"
+#include "rpc2x_act.tab.h"
 #include "output.h"
 
 static DriverVector *drv;

--- a/output2elide.pl
+++ b/output2elide.pl
@@ -43,10 +43,10 @@ $locode = $hicode = undef;
 while (<>) {
     chomp;
     last if (/^\s*$/);
-    next if (/^\s/);
-    next if (/^\$/);
+    next if (/^\s+[0-9]/);
+    next if (/^\s*\$/);
 
-    m{^([^ \t]+)\s+\(([-0-9]+)\)} || die "Unmatched line [$_];";
+    m{^\s*([^ \t0-9][^ \t]*)\s+\(([-0-9]+)\)} || die "Unmatched line [$_];";
     $codes{$1} = $2;
     if (!(defined $locode) || ($locode > $2)) { $locode = $2; }
     if (!(defined $hicode) || ($hicode < $2)) { $hicode = $2; }
@@ -57,7 +57,7 @@ $state = undef;
 
 while (<>) {
     chomp;
-    if (/^state ([0-9]+)/) {
+    if (/^[Ss]tate ([0-9]+)/) {
         $state = $1;
         next;
     }

--- a/output2table.pl
+++ b/output2table.pl
@@ -74,9 +74,9 @@ $_ = <STDIN>;
 while (<>) {
     chomp;
     last if (/^\s*$/);
-    next if (/^\s/);
+    next if (/^\s+[0-9]/);
 
-    m{^([^ \t]+)} || die "Unmatched line [$_];";
+    m{^[ \t]*([^0-9 \t][^ \t]*)} || die "Unmatched line [$_];";
     $codes{$1} = $hicode++;
 }
 
@@ -95,7 +95,7 @@ $latest_lhs = undef;
 
 while (<>) {
     chomp;
-    if (/^state ([0-9]+)/) {
+    if (/^[Ss]tate ([0-9]+)/) {
         $state = $1;
         $rules[$state] = [ ];
         $focus[$state] = [ ];
@@ -111,7 +111,7 @@ while (<>) {
         $ruleno = $3;
         @r = split(/ /, $rhs);
         for ($i = 0; ; $i++) {
-            last if ($r[$i] eq '.');
+            last if ($r[$i] =~ /\.|•/);
         }
         push (@{$focus[$state]}, $i);
         push (@{$rules[$state]}, $ruleno);
@@ -124,7 +124,7 @@ while (<>) {
         $rhs = $3;
         @r = split(/ /, $rhs);
         for ($i = 0; ; $i++) {
-            last if ($r[$i] eq '.');
+            last if ($r[$i] =~ /\.|•/);
         }
         push (@{$focus[$state]}, $i);
         push (@{$rules[$state]}, $ruleno);
@@ -135,7 +135,7 @@ while (<>) {
         $rhs = $2;
         @r = split(/ /, $rhs);
         for ($i = 0; ; $i++) {
-            last if ($r[$i] eq '.');
+            last if ($r[$i] =~ /\.|•/);
         }
         push (@{$focus[$state]}, $i);
         push (@{$rules[$state]}, $ruleno);

--- a/relative.c
+++ b/relative.c
@@ -10,7 +10,7 @@
 #include <assert.h>
 
 #include "nodes.h"
-#include "rpc_tab.h"
+#include "rpc2x_act.tab.h"
 #include "functions.h"
 #include "cmavotab.h"
 

--- a/tenses.c
+++ b/tenses.c
@@ -18,7 +18,7 @@
 #include <string.h>
 #include <assert.h>
 
-#include "rpc_tab.h"
+#include "rpc2x_act.tab.h"
 #include "nonterm.h"
 #include "functions.h"
 

--- a/terms.c
+++ b/terms.c
@@ -14,7 +14,7 @@
 #include <string.h>
 
 #include "functions.h"
-#include "rpc_tab.h"
+#include "rpc2x_act.tab.h"
 #include "nodes.h"
 #include "cmavotab.h"
 /*}}}*/

--- a/tree.c
+++ b/tree.c
@@ -13,7 +13,7 @@
 #include "nonterm.h"
 #include "functions.h"
 #include "cmavotab.h"
-#include "rpc_tab.h"
+#include "rpc2x_act.tab.h"
 
 /*++++++++++++++++++++++++++++++
   Work through the tree and eliminate any nodes that only have single


### PR DESCRIPTION
Fix #11 :

* pass -fcommon to gcc
* stop renaming .h files output by bison, as bison .c files refer to them
* tweak perl scripts to accept current bison output

This might break earlier bison versions; I haven't tried any earlier than 3.3.