### PR TITLE
Assorted jvocuhadju updates and bugfixes

### DIFF
--- a/jvocuhadju.1
+++ b/jvocuhadju.1
@@ -4,7 +4,7 @@ jvocuhadju \- Lujvo picker (based on the rules in the reference grammar.)
 .SH SYNOPSIS
 .PP
 .B jvocuhadju
-[-v] [-a] [-l]
+[-v] [-a] [-l] [-R]
 .I tanru-component-1
 [
 .BR "" ...
@@ -33,6 +33,9 @@ List all possible lujvo for the input tanru (default is just the best 8).
 .B -l
 Allow 4/5 letter rafsi to be picked even if a 3 letter form is available for
 any particular tanru component.
+.TP
+.B -R
+Do not display the list of possiblerafsi.
 .TP
 .B tanru-component-k
 This is a gismu or cmavo which is one component of the word.  Cmavo

--- a/jvocuhadju.1
+++ b/jvocuhadju.1
@@ -4,7 +4,7 @@ jvocuhadju \- Lujvo picker (based on the rules in the reference grammar.)
 .SH SYNOPSIS
 .PP
 .B jvocuhadju
-[-v] [-a] [-l] [-R]
+[-v] [-a] [-l] [-R] [-S] [-q]
 .I tanru-component-1
 [
 .BR "" ...
@@ -44,6 +44,9 @@ Do not display the list of possible rafsi.
 .TP
 .B -S
 Do not display the lujvo score.
+.TP
+.B -q
+Do not display various info messages.
 .TP
 .B tanru-component-k
 This is a gismu or cmavo which is one component of the word.  Cmavo

--- a/jvocuhadju.1
+++ b/jvocuhadju.1
@@ -42,6 +42,9 @@ either "brodo", "brode", "brodi", "brodo" or "brodu".
 .B -R
 Do not display the list of possible rafsi.
 .TP
+.B -S
+Do not display the lujvo score.
+.TP
 .B tanru-component-k
 This is a gismu or cmavo which is one component of the word.  Cmavo
 must have a rafsi corresponding to them.

--- a/jvocuhadju.1
+++ b/jvocuhadju.1
@@ -4,7 +4,7 @@ jvocuhadju \- Lujvo picker (based on the rules in the reference grammar.)
 .SH SYNOPSIS
 .PP
 .B jvocuhadju
-[-v] [-a] [-l] [-R] [-S] [-q]
+[-v] [-a] [-l] [-R] [-S] [-A] [-q]
 .I tanru-component-1
 [
 .BR "" ...
@@ -44,6 +44,10 @@ Do not display the list of possible rafsi.
 .TP
 .B -S
 Do not display the lujvo score.
+.TP
+.B -A
+Do not display annotations. By default, the best-scoring lujvo will be annotated
+with an asterisk character at the beginning of the line.
 .TP
 .B -q
 Do not display various info messages.

--- a/jvocuhadju.1
+++ b/jvocuhadju.1
@@ -34,8 +34,13 @@ List all possible lujvo for the input tanru (default is just the best 8).
 Allow 4/5 letter rafsi to be picked even if a 3 letter form is available for
 any particular tanru component.
 .TP
+.B -b
+Allow to use the rafsi "brod" (from the "broda" series).
+This rafsi is suppressed by default because of ambiguity; it could stand for
+either "brodo", "brode", "brodi", "brodo" or "brodu".
+.TP
 .B -R
-Do not display the list of possiblerafsi.
+Do not display the list of possible rafsi.
 .TP
 .B tanru-component-k
 This is a gismu or cmavo which is one component of the word.  Cmavo

--- a/jvocuhadju.c
+++ b/jvocuhadju.c
@@ -759,11 +759,21 @@ static void makelujvo(char **tanru) {
   /* Now have to work through all combinations of rafsi. */
   /* Print out rafsi for checking */
   printf("Possible rafsi for input words :\n");
+  int missing_rafsi = -1;
   for (i=0; i<nt; i++) {
+    printf("%s: ", t[i]);
     for (j=0; j<nr[i]; j++) {
       printf("%s ", r[i][j]);
     }
+    if (nr[i] == 0) {
+      printf("<NONE> ", t[i]);
+      missing_rafsi = i;
+    }
     printf("\n");
+  }
+  if (missing_rafsi != -1) {
+    fprintf(stderr, "No matching rafsi available for component [%s] at position %d\n", t[missing_rafsi], missing_rafsi+1);
+    exit(1);
   }
   printf("--------------------\n");
   printf(" Score  Lujvo\n");

--- a/jvocuhadju.c
+++ b/jvocuhadju.c
@@ -708,6 +708,7 @@ static void makelujvo(char **tanru) {
   int lujvo_limit_hit = 0; /* set to 1 if there's a huge number of possible lujvo */
   int brod_rafsi_used = 0; /* set to 1 if the rafsi 'brod' was used. Set to 2
                               if it was suppressed. */
+  int hidden_lujvo = 0;    /* Number of lujvo hidden from view */
 
   int check1, check2, check3, check4;
 
@@ -1009,11 +1010,17 @@ static void makelujvo(char **tanru) {
 
   qsort(lujvo, nl, sizeof(Lujvo), compare_lujvo);
 
-  if (!showall && (nl>MAX_LUJVO_SHOWN)) nl = MAX_LUJVO_SHOWN;
+  if (!showall && (nl>MAX_LUJVO_SHOWN)) {
+    hidden_lujvo = nl - MAX_LUJVO_SHOWN;
+    nl = MAX_LUJVO_SHOWN;
+  }
   for (i=0; i<nl; i++) {
     printf("%c%6d  %s\n", lujvo[i].marker, lujvo[i].score, lujvo[i].word);
   }
 
+  if (hidden_lujvo > 0) {
+    fprintf(stdout, "(%d lujvo hidden, use \"-a\" to see all)\n", hidden_lujvo);
+  }
   if (brod_rafsi_used == 1) {
     fprintf(stderr, "Warning: The rafsi \"brod\" used in the lujvo above is ambigious!\n");
     fprintf(stderr, "It could stand for \"broda\", \"brode\", \"brodi\", \"brodo\" or \"brodu\".\n");

--- a/jvocuhadju.c
+++ b/jvocuhadju.c
@@ -24,7 +24,8 @@ static int uselong = 0;   /* Consider lujvo including long rafsi when short ones
 static int showall = 0;   /* List all lujvo, not just the best MAX_LUJVO_SHOWN of them */
 static int showrafsi = 1; /* List the possible rafsi at the beginning */
 static int allowbrod = 0; /* Allow to use the "brod" rafsi (from the "broda" series) */
-static int showscore = 1;   /* Don't print the lujvo score */
+static int showscore = 1; /* Don't print the lujvo score */
+static int quiet = 0;     /* Suppress various info messages */
 
 static int ends_in_vowel(char *s) {
   char *p;
@@ -802,7 +803,7 @@ static void makelujvo(char **tanru) {
     }
     if (missing_rafsi != -1) {
       fprintf(stderr, "No matching rafsi available for component [%s] at position %d.\n", t[missing_rafsi], missing_rafsi+1);
-      if (brod_rafsi_used == 2) {
+      if (!quiet && brod_rafsi_used == 2) {
         fprintf(stdout, "Note: The rafsi \"brod\" was suppressed. Use \"-b\" to force it.\n");
       }
       exit(1);
@@ -1043,13 +1044,13 @@ static void makelujvo(char **tanru) {
     }
   }
 
-  if (hidden_lujvo > 0) {
+  if (!quiet && hidden_lujvo > 0) {
     fprintf(stdout, "(%d lujvo hidden, use \"-a\" to see all)\n", hidden_lujvo);
   }
   if (brod_rafsi_used == 1) {
     fprintf(stderr, "Warning: The rafsi \"brod\" is ambigious!\n");
     fprintf(stderr, "It could stand for \"broda\", \"brode\", \"brodi\", \"brodo\" or \"brodu\".\n");
-  } else if (brod_rafsi_used == 2) {
+  } else if (!quiet && brod_rafsi_used == 2) {
     fprintf(stdout, "Note: The rafsi \"brod\" was suppressed. Use \"-b\" to force it.\n");
   }
   if (lujvo_limit_hit) {
@@ -1076,6 +1077,8 @@ int main (int argc, char **argv) {
       showscore = 0;
     } else if (!strcmp(*argv, "-R")) {
       showrafsi = 0;
+    } else if (!strcmp(*argv, "-q")) {
+      quiet = 1;
     } else if ((*argv)[0] == '-') {
       fprintf(stderr, "Unrecognised command line option %s.\n", *argv);
       exit(1);

--- a/jvocuhadju.c
+++ b/jvocuhadju.c
@@ -771,9 +771,9 @@ static void makelujvo(char **tanru) {
     int missing_rafsi = -1;
     for (i=0; i<nt; i++) {
       if (showrafsi) {
-        printf("%5s:  ", t[i]);
+        printf("%-5s:  ", t[i]);
         for (j=0; j<nr[i]; j++) {
-          printf("%s ", r[i][j]);
+          printf("%-5s ", r[i][j]);
         }
         if (nr[i] == 0) {
           printf("<NONE> ", t[i]);

--- a/jvocuhadju.c
+++ b/jvocuhadju.c
@@ -1034,7 +1034,7 @@ static void makelujvo(char **tanru) {
     fprintf(stdout, "(%d lujvo hidden, use \"-a\" to see all)\n", hidden_lujvo);
   }
   if (brod_rafsi_used == 1) {
-    fprintf(stderr, "Warning: The rafsi \"brod\" used in the lujvo above is ambigious!\n");
+    fprintf(stderr, "Warning: The rafsi \"brod\" is ambigious!\n");
     fprintf(stderr, "It could stand for \"broda\", \"brode\", \"brodi\", \"brodo\" or \"brodu\".\n");
   } else if (brod_rafsi_used == 2) {
     fprintf(stdout, "Note: The rafsi \"brod\" was suppressed. Use \"-b\" to force it.\n");

--- a/jvocuhadju.c
+++ b/jvocuhadju.c
@@ -24,6 +24,7 @@ static int uselong = 0;   /* Consider lujvo including long rafsi when short ones
 static int showall = 0;   /* List all lujvo, not just the best MAX_LUJVO_SHOWN of them */
 static int showrafsi = 1; /* List the possible rafsi at the beginning */
 static int allowbrod = 0; /* Allow to use the "brod" rafsi (from the "broda" series) */
+static int showscore = 1;   /* Don't print the lujvo score */
 
 static int ends_in_vowel(char *s) {
   char *p;
@@ -812,9 +813,13 @@ static void makelujvo(char **tanru) {
     exit(1);
   }
   /* Print out the lujvo scores */
-  printf("---------------------\n");
-  printf("  Score  Lujvo\n");
-  printf("---------------------\n");
+  if(showscore) {
+    printf("---------------------\n");
+    printf("  Score  Lujvo\n");
+    printf("---------------------\n");
+  } else if (showrafsi) {
+    printf("List of lujvo:\n");
+  }
 
   /* Initialise multi dimensional loop */
   for (i=0; i<nt; i++) {
@@ -1031,7 +1036,11 @@ static void makelujvo(char **tanru) {
     nl = MAX_LUJVO_SHOWN;
   }
   for (i=0; i<nl; i++) {
-    printf("%c%6d  %s\n", lujvo[i].marker, lujvo[i].score, lujvo[i].word);
+    if (showscore) {
+      printf("%c%6d  %s\n", lujvo[i].marker, lujvo[i].score, lujvo[i].word);
+    } else {
+      printf("%c %s\n", lujvo[i].marker, lujvo[i].word);
+    }
   }
 
   if (hidden_lujvo > 0) {
@@ -1063,6 +1072,8 @@ int main (int argc, char **argv) {
       uselong = 1;
     } else if (!strcmp(*argv, "-b")) {
       allowbrod = 1;
+    } else if (!strcmp(*argv, "-S")) {
+      showscore = 0;
     } else if (!strcmp(*argv, "-R")) {
       showrafsi = 0;
     } else if ((*argv)[0] == '-') {

--- a/jvocuhadju.c
+++ b/jvocuhadju.c
@@ -758,10 +758,10 @@ static void makelujvo(char **tanru) {
 
   /* Now have to work through all combinations of rafsi. */
   /* Print out rafsi for checking */
-  printf("Possible rafsi for input words :\n");
+  printf("Possible rafsi for input words:\n");
   int missing_rafsi = -1;
   for (i=0; i<nt; i++) {
-    printf("%s: ", t[i]);
+    printf("%5s:  ", t[i]);
     for (j=0; j<nr[i]; j++) {
       printf("%s ", r[i][j]);
     }
@@ -965,7 +965,7 @@ static void makelujvo(char **tanru) {
 
   if (!showall && (nl>MAXLUJVO)) nl = MAXLUJVO;
   for (i=0; i<nl; i++) {
-    printf("%6d %s\n", lujvo[i].score, lujvo[i].word);
+    printf("%6d  %s\n", lujvo[i].score, lujvo[i].word);
   }
 
 }

--- a/jvocuhadju.c
+++ b/jvocuhadju.c
@@ -721,7 +721,7 @@ static void makelujvo(char **tanru) {
     }
     index = lookup_gismu(t[i]);
     if (index < 0) {
-      fprintf(stderr, "Cannot use component [%s] in forming lujvo\n", t[i]);
+      fprintf(stderr, "Cannot use component [%s] in forming lujvo.\n", t[i]);
       exit(1);
     }
 
@@ -799,7 +799,7 @@ static void makelujvo(char **tanru) {
       }
     }
     if (missing_rafsi != -1) {
-      fprintf(stderr, "No matching rafsi available for component [%s] at position %d\n", t[missing_rafsi], missing_rafsi+1);
+      fprintf(stderr, "No matching rafsi available for component [%s] at position %d.\n", t[missing_rafsi], missing_rafsi+1);
       if (brod_rafsi_used == 2) {
         fprintf(stdout, "Note: The rafsi \"brod\" was suppressed. Use \"-b\" to force it.\n");
       }
@@ -807,7 +807,7 @@ static void makelujvo(char **tanru) {
     }
   }
   if (nt < 2) {
-    fprintf(stderr, "Not enough components for lujvo (need at least 2)\n");
+    fprintf(stderr, "Not enough components for lujvo (need at least 2).\n");
     exit(1);
   }
   /* Print out the lujvo scores */
@@ -887,7 +887,7 @@ static void makelujvo(char **tanru) {
         if (is_valid_lujvo(temp)) {
           /* Add glue after 1st rafsi */
 #if 0
-          printf("Glue needed\n");
+          printf("Glue needed.\n");
 #endif
           g[0] = 'y';
         }
@@ -967,7 +967,7 @@ static void makelujvo(char **tanru) {
                    is_vowel(r[i][c[i]][2])) {
           rr = 8;
         } else {
-          fprintf(stderr, "Unmatched rafsi [%s]\n", r[i][c[i]]);
+          fprintf(stderr, "Unmatched rafsi [%s].\n", r[i][c[i]]);
           exit(1);
         }
         /* Warning about ambigious rafsi 'brod' */
@@ -1021,7 +1021,7 @@ static void makelujvo(char **tanru) {
     fprintf(stdout, "Note: The rafsi \"brod\" was suppressed. Use \"-b\" to force it.\n");
   }
   if (lujvo_limit_hit) {
-    fprintf(stderr, "Warning: There are over %d possible lujvo, some possible lujvo weren't checked\n", MAX_LUJVO_COUNT);
+    fprintf(stderr, "Warning: There are over %d possible lujvo, some possible lujvo weren't checked.\n", MAX_LUJVO_COUNT);
   }
 }
 
@@ -1043,7 +1043,7 @@ int main (int argc, char **argv) {
     } else if (!strcmp(*argv, "-R")) {
       showrafsi = 0;
     } else if ((*argv)[0] == '-') {
-      fprintf(stderr, "Unrecognised command line option %s\n", *argv);
+      fprintf(stderr, "Unrecognised command line option %s.\n", *argv);
       exit(1);
     } else {
       word_counter++;

--- a/jvocuhadju.c
+++ b/jvocuhadju.c
@@ -24,7 +24,8 @@ static int uselong = 0;   /* Consider lujvo including long rafsi when short ones
 static int showall = 0;   /* List all lujvo, not just the best MAX_LUJVO_SHOWN of them */
 static int showrafsi = 1; /* List the possible rafsi at the beginning */
 static int allowbrod = 0; /* Allow to use the "brod" rafsi (from the "broda" series) */
-static int showscore = 1; /* Don't print the lujvo score */
+static int showscore = 1; /* Print the lujvo score */
+static int showannotations = 1; /* Print lujvo annotations */
 static int quiet = 0;     /* Suppress various info messages */
 
 static int ends_in_vowel(char *s) {
@@ -675,7 +676,7 @@ static int lookup_gismu(char *s) {
 typedef struct {
   char *word;
   long long int score;
-  char marker; /* special symbol for lujvo list for footnotes */
+  char annotation; /* special symbol for lujvo list for footnotes */
 } Lujvo;
 
 static Lujvo lujvo[MAX_LUJVO_COUNT];
@@ -816,7 +817,11 @@ static void makelujvo(char **tanru) {
   /* Print out the lujvo scores */
   if(showscore) {
     printf("---------------------\n");
-    printf("  Score  Lujvo\n");
+    if(showannotations) {
+      printf("  Score  Lujvo\n");
+    } else {
+      printf(" Score  Lujvo\n");
+    }
     printf("---------------------\n");
   } else if (showrafsi) {
     printf("List of lujvo:\n");
@@ -922,7 +927,7 @@ static void makelujvo(char **tanru) {
       printf("%s\n", temp);
 #endif
       lujvo[nl].word = (char *) malloc(strlen(temp) + 1);
-      lujvo[nl].marker = ' ';
+      lujvo[nl].annotation= ' ';
       strcpy(lujvo[nl].word, temp);
 
       /* Work out score */
@@ -979,7 +984,7 @@ static void makelujvo(char **tanru) {
         }
         /* Warning about ambigious rafsi 'brod' */
         if (strlen(r[i][c[i]]) == 4 && strncmp(r[i][c[i]], "brod", 4) == 0) {
-           lujvo[nl].marker = '!';
+           lujvo[nl].annotation= '!';
            brod_rafsi_used = 1;
         }
 #if 0
@@ -1017,15 +1022,15 @@ static void makelujvo(char **tanru) {
   qsort(lujvo, nl, sizeof(Lujvo), compare_lujvo);
 
   // Give a star to the winning lujvo ;-)
-  if (lujvo[0].marker != '!') {
-    lujvo[0].marker = '*';
+  if (lujvo[0].annotation!= '!') {
+    lujvo[0].annotation= '*';
   }
 
   // lujvo that are tied for the lead also get a star
   for (i=1; i<nl; i++) {
     if (lujvo[i].score == lujvo[0].score) {
-      if (lujvo[0].marker != '!') {
-        lujvo[i].marker = '*';
+      if (lujvo[0].annotation!= '!') {
+        lujvo[i].annotation = '*';
       }
     } else {
       break;
@@ -1038,9 +1043,17 @@ static void makelujvo(char **tanru) {
   }
   for (i=0; i<nl; i++) {
     if (showscore) {
-      printf("%c%6d  %s\n", lujvo[i].marker, lujvo[i].score, lujvo[i].word);
+      if (showannotations) {
+        printf("%c%6d  %s\n", lujvo[i].annotation, lujvo[i].score, lujvo[i].word);
+      } else {
+        printf("%6d  %s\n", lujvo[i].score, lujvo[i].word);
+      }
     } else {
-      printf("%c %s\n", lujvo[i].marker, lujvo[i].word);
+      if (showannotations) {
+        printf("%c %s\n", lujvo[i].annotation, lujvo[i].word);
+      } else {
+        printf("%s\n", lujvo[i].word);
+      }
     }
   }
 
@@ -1075,6 +1088,8 @@ int main (int argc, char **argv) {
       allowbrod = 1;
     } else if (!strcmp(*argv, "-S")) {
       showscore = 0;
+    } else if (!strcmp(*argv, "-A")) {
+      showannotations = 0;
     } else if (!strcmp(*argv, "-R")) {
       showrafsi = 0;
     } else if (!strcmp(*argv, "-q")) {

--- a/jvocuhadju.c
+++ b/jvocuhadju.c
@@ -760,23 +760,30 @@ static void makelujvo(char **tanru) {
 
   /* Now have to work through all combinations of rafsi. */
   /* Print out rafsi for checking */
-  printf("Possible rafsi for input words:\n");
-  int missing_rafsi = -1;
-  for (i=0; i<nt; i++) {
-    printf("%5s:  ", t[i]);
-    for (j=0; j<nr[i]; j++) {
-      printf("%s ", r[i][j]);
+  if (nt >= 1) {
+    printf("Possible rafsi for input words:\n");
+    int missing_rafsi = -1;
+    for (i=0; i<nt; i++) {
+      printf("%5s:  ", t[i]);
+      for (j=0; j<nr[i]; j++) {
+        printf("%s ", r[i][j]);
+      }
+      if (nr[i] == 0) {
+        printf("<NONE> ", t[i]);
+        missing_rafsi = i;
+      }
+      printf("\n");
     }
-    if (nr[i] == 0) {
-      printf("<NONE> ", t[i]);
-      missing_rafsi = i;
+    if (missing_rafsi != -1) {
+      fprintf(stderr, "No matching rafsi available for component [%s] at position %d\n", t[missing_rafsi], missing_rafsi+1);
+      exit(1);
     }
-    printf("\n");
   }
-  if (missing_rafsi != -1) {
-    fprintf(stderr, "No matching rafsi available for component [%s] at position %d\n", t[missing_rafsi], missing_rafsi+1);
+  if (nt < 2) {
+    fprintf(stderr, "Not enough components for lujvo (need at least 2)\n");
     exit(1);
   }
+  /* Print out the lujvo scores */
   printf("--------------------\n");
   printf(" Score  Lujvo\n");
   printf("--------------------\n");

--- a/jvocuhadju.c
+++ b/jvocuhadju.c
@@ -999,6 +999,7 @@ static void makelujvo(char **tanru) {
 int main (int argc, char **argv) {
   char *words[MAXT];
   char **wp;
+  int word_counter = 0;
   wp = words;
   while (++argv, --argc) {
     if (!strcmp(*argv, "-v")) {
@@ -1014,6 +1015,11 @@ int main (int argc, char **argv) {
       fprintf(stderr, "Unrecognised command line option %s\n", *argv);
       exit(1);
     } else {
+      word_counter++;
+      if (word_counter >= MAXT) {
+        fprintf(stderr, "Too many components! (more than %d)!\n", MAXT-1);
+        exit(1);
+      }
       *wp = *argv;
       ++wp;
     }

--- a/jvocuhadju.c
+++ b/jvocuhadju.c
@@ -665,13 +665,14 @@ static int lookup_gismu(char *s) {
 }
 
 #define MAXT 50
+#define MAX_LUJVO 65536
 
 typedef struct {
   char *word;
-  int score;
+  long long int score;
 } Lujvo;
 
-static Lujvo lujvo[65536];
+static Lujvo lujvo[MAX_LUJVO];
 static int nl = 0;
 
 /* Comparison function for qsort() */
@@ -702,6 +703,7 @@ static void makelujvo(char **tanru) {
   int index, si;
   int c[MAXT]; /* Counters over the rafsi forms for each argument
                   (implements an arbitrarily-nested for loop) */
+  int lujvo_limit_hit = 0; /* set to 1 if there's a huge number of possible lujvo */
 
   int check1, check2, check3, check4;
 
@@ -944,6 +946,10 @@ static void makelujvo(char **tanru) {
       lujvo[nl].score = 1000*L - 500*A + 100*H - 10*R - V;
       nl++;
     }
+    if (nl >= MAX_LUJVO) {
+       lujvo_limit_hit = 1;
+       break;
+    }
 
     /* Bump counter array */
     {
@@ -968,6 +974,9 @@ static void makelujvo(char **tanru) {
     printf("%6d  %s\n", lujvo[i].score, lujvo[i].word);
   }
 
+  if (lujvo_limit_hit == 1) {
+    fprintf(stdout, "Warning: There are over %d possible lujvo, some possible lujvo weren't checked\n", MAX_LUJVO);
+  }
 }
 
 int main (int argc, char **argv) {

--- a/jvocuhadju.c
+++ b/jvocuhadju.c
@@ -20,8 +20,9 @@
 #define MAX_LUJVO_COUNT 65536   /* Max. number of lujvo to check */
 #define MAX_LUJVO_SHOWN 8       /* Max. number of top lujvo to show by default */
 
-static int uselong = 0; /* Consider lujvo including long rafsi when short ones are available */
-static int showall = 0; /* List all lujvo, not just the best MAX_LUJVO_SHOWN of them */
+static int uselong = 0;   /* Consider lujvo including long rafsi when short ones are available */
+static int showall = 0;   /* List all lujvo, not just the best MAX_LUJVO_SHOWN of them */
+static int showrafsi = 1; /* List the possible rafsi at the beginning */
 
 static int ends_in_vowel(char *s) {
   char *p;
@@ -760,22 +761,28 @@ static void makelujvo(char **tanru) {
   /* Now have to work through all combinations of rafsi. */
   /* Print out rafsi for checking */
   if (nt >= 1) {
-    if (uselong) {
-      printf("Possible rafsi for input words:\n");
-    } else {
-      printf("Possible rafsi for input words (avoiding long rafsi):\n");
+    if (showrafsi) {
+      if (uselong) {
+        printf("Possible rafsi for input words:\n");
+      } else {
+        printf("Possible rafsi for input words (avoiding long rafsi):\n");
+      }
     }
     int missing_rafsi = -1;
     for (i=0; i<nt; i++) {
-      printf("%5s:  ", t[i]);
-      for (j=0; j<nr[i]; j++) {
-        printf("%s ", r[i][j]);
+      if (showrafsi) {
+        printf("%5s:  ", t[i]);
+        for (j=0; j<nr[i]; j++) {
+          printf("%s ", r[i][j]);
+        }
+        if (nr[i] == 0) {
+          printf("<NONE> ", t[i]);
+        }
+        printf("\n");
       }
       if (nr[i] == 0) {
-        printf("<NONE> ", t[i]);
         missing_rafsi = i;
       }
-      printf("\n");
     }
     if (missing_rafsi != -1) {
       fprintf(stderr, "No matching rafsi available for component [%s] at position %d\n", t[missing_rafsi], missing_rafsi+1);
@@ -1001,6 +1008,8 @@ int main (int argc, char **argv) {
       showall = 1;
     } else if (!strcmp(*argv, "-l")) {
       uselong = 1;
+    } else if (!strcmp(*argv, "-R")) {
+      showrafsi = 0;
     } else if ((*argv)[0] == '-') {
       fprintf(stderr, "Unrecognised command line option %s\n", *argv);
       exit(1);

--- a/jvocuhadju.c
+++ b/jvocuhadju.c
@@ -1010,6 +1010,18 @@ static void makelujvo(char **tanru) {
 
   qsort(lujvo, nl, sizeof(Lujvo), compare_lujvo);
 
+  // Give a star to the winning lujvo ;-)
+  lujvo[0].marker = '*';
+
+  // lujvo that are tied for the lead also get a star
+  for (i=1; i<nl; i++) {
+    if (lujvo[i].score == lujvo[0].score) {
+      lujvo[i].marker = '*';
+    } else {
+      break;
+    }
+  }
+
   if (!showall && (nl>MAX_LUJVO_SHOWN)) {
     hidden_lujvo = nl - MAX_LUJVO_SHOWN;
     nl = MAX_LUJVO_SHOWN;

--- a/jvocuhadju.c
+++ b/jvocuhadju.c
@@ -1011,12 +1011,16 @@ static void makelujvo(char **tanru) {
   qsort(lujvo, nl, sizeof(Lujvo), compare_lujvo);
 
   // Give a star to the winning lujvo ;-)
-  lujvo[0].marker = '*';
+  if (lujvo[0].marker != '!') {
+    lujvo[0].marker = '*';
+  }
 
   // lujvo that are tied for the lead also get a star
   for (i=1; i<nl; i++) {
     if (lujvo[i].score == lujvo[0].score) {
-      lujvo[i].marker = '*';
+      if (lujvo[0].marker != '!') {
+        lujvo[i].marker = '*';
+      }
     } else {
       break;
     }


### PR DESCRIPTION
This PR adds a couple of assorted bugfixes and minor feature updates to `jvocuhadju`.

* Bugfix: Pointless lujvo output if 0 or 1 word was given
* Fix various segfaults for bad inputs
* Improved readability of rafsi list
* Update: Improved error messages and warnings
* Feature: Suppress using the ambigious “brod” rafsi (from the “broda” gismu series) by default, re-enable with '-b' parameter (see also: <https://github.com/Wuzzy2/jbofihe.git>)
* Feature: Suppress rafsi list with '-R' parameter