### PR TITLE
Fix undefined behavior in evaluate_result caused by read of uninitialized symbol value

### DIFF
--- a/dfasyn/expr.c
+++ b/dfasyn/expr.c
@@ -214,6 +214,7 @@ static Symbol *  find_symbol_or_create(Evaluator *x, char *sym_name)/*{{{*/
   add_new_symbol(x,s);
   s->is_expr = 0; /* Until proven otherwise */
   s->name = new_string(sym_name);
+  s->data.val = 0;
   return s;
 }
 /*}}}*/


### PR DESCRIPTION
ui coi lei bangu pendo .i zu'e mi pu co'u samrkompli le'i vi proga ri'a le du'u la'e la'oi dfasyn na genturfa'i la'e la'o dac. morf_nfa.in .dac lu'u voi samdacru ku'o co'i le nu la'e la'oi dfasyn cusku zoi gy. No output written, there were ambiguous exit values for accepting states .gy .i mi na pu djuno le su'u na'ebo mi snada le mu'e samrkompli kei be lo tadji .i ba bo mi pu facki ri'a le zu'o mi lanli loi samselpla kei le du'u la'e la'oi evaluate_result cu pilno pa da poi namcu vefi'e lei to'e selsmudu'a selkanji skami bo morji ku'o le zu'o kanji le jei da zmadu li no sebai le nu co'u genturfa'i ku kei goi ko'a .i le jei ko'a pu du li pa va'o le pe mi skami .i mi pu setca pa lo midvla ku poi smudu'a le ba seljetlai sinxa ku poi se finti la'e la'oi find_symbol_or_create ku'o li no ku'o gi'e ru ca tolpo'u .i mi pacna dei poi ka du'enai zu'i valsi .i mi jidge ru'a le li'i rapcreze'a le zu'u tavla fo la .lojban.

(loose translation, I wrote the first part first lol) Hi language friends :3 . I could not compile these programs because "dfasyn" would not parse the file "morf_nfa.in" and would print  "No output written, there were ambiguous exit values for accepting states". I didn't know why it worked for everyone else so I looked around the code and discovered that the function "evaluate_result" reads from uninitialized memory to determine if parsing should cease. On my machine, it determines that it should. I added an instruction to initialize the value of future symbols created by the function "find_symbol_or_create" to 0 and everything works now. I hope this is not too wordy. I thought this would be a good opportunity to practice speaking Lojban. (translation ends)

Just to be clear, the call stack at where the symbol with the uninitialized value is created looks something like: [other stuff]->add_dfa->evaluate_result->eval->find_symbol_or_create, then the bad symbol value propagates back up to `evaluate_result`, because `eval` returns the value of the symbol without checking if it is a new, uninitialized-value-having symbol (the "create" part of `find_symbol_or_create`), where it is read as the condition of `if (eval(x, x->results[i].e))`. There is definitely much more undefined behavior going on in this very dusty program, but fixing that did make it work for me on amd64 OpenBSD, which has a tendency to reveal before-unseen bugs in programs :3

It's a one line diff but....... I'm sure you have enough details now lol

co'o