### PR TITLE
Fix build with gcc14

### DIFF
--- a/add_trace_to_tabc.pl
+++ b/add_trace_to_tabc.pl
@@ -15,11 +15,11 @@
 # COPYRIGHT
 
 print <<EOF;
-extern elide_trace_reduce(int, int);
-extern elide_trace_shift(int,int);
-extern report_trace_shift(int);
-extern report_trace_reduce(int, int);
-extern report_trace_error(short *yyss, short *yyssp);
+extern void elide_trace_reduce(int, int);
+extern void elide_trace_shift(int,int);
+extern void report_trace_shift(int);
+extern void report_trace_reduce(int, int);
+extern void report_trace_error(short *yyss, short *yyssp);
 EOF
 
 while (<>) {

--- a/dfasyn/n2d.h
+++ b/dfasyn/n2d.h
@@ -181,6 +181,10 @@ Expr * new_xor_expr(Expr *c1, Expr *c2);
 Expr * new_cond_expr(Expr *c1, Expr *c2, Expr *c3);
 Expr * new_sym_expr(char *sym_name);
 
+int yyparse(void);
+void yyerror(char *);
+int yylex(void);
+
 void define_symbol(Evaluator *x, char *name, Expr *e);
 void define_result(Evaluator *x, char *string, Expr *e, int early);
 void define_symresult(Evaluator *x, char *string, Expr *e, int early);


### PR DESCRIPTION
Fix implicit-int errors with gcc14

- add explicit `void` return type for: `elide_trace_reduce`,
`elide_trace_shift`, `report_trace_shift`, `report_trace_reduce` and
`report_trace_error`

Fixes `implicit-int` errors:
```
rpc_tab.c:1:8: error: type defaults to 'int' in declaration of
'elide_trace_reduce' [-Wimplicit-int]
    1 | extern elide_trace_reduce(int, int);
      |        ^~~~~~~~~~~~~~~~~~
rpc_tab.c:2:8: error: type defaults to 'int' in declaration of
'elide_trace_shift' [-Wimplicit-int]
    2 | extern elide_trace_shift(int,int);
      |        ^~~~~~~~~~~~~~~~~
rpc_tab.c:3:8: error: type defaults to 'int' in declaration of
'report_trace_shift' [-Wimplicit-int]
    3 | extern report_trace_shift(int);
      |        ^~~~~~~~~~~~~~~~~~
rpc_tab.c:4:8: error: type defaults to 'int' in declaration of
'report_trace_reduce' [-Wimplicit-int]
    4 | extern report_trace_reduce(int, int);
      |        ^~~~~~~~~~~~~~~~~~~
rpc_tab.c:5:8: error: type defaults to 'int' in declaration of
'report_trace_error' [-Wimplicit-int]
    5 | extern report_trace_error(short *yyss, short *yyssp);
      |        ^~~~~~~~~~~~~~~~~~
```

---

Fix implicit-function-declaration errors with gcc14

- add declarations for `yylex`, `yyerror` and `yyparse` to `n2d.h`

Fixes `implicit-function-declaration` errors:
```
parse.tab.c: In function 'yyparse':
parse.tab.c:1148:16: error: implicit declaration of function 'yylex'
[-Wimplicit-function-declaration]
 1148 |       yychar = yylex ();
      |                ^~~~~

parse.tab.c:1595:7: error: implicit declaration of function 'yyerror';
did you mean 'yyerrok'? [-Wimplicit-function-declaration]
 1595 |       yyerror (YY_("syntax error"));
      |       ^~~~~~~
      |       yyerrok

n2d.c: In function 'main':
n2d.c:1529:12: error: implicit declaration of function 'yyparse'
[-Wimplicit-function-declaration]
 1529 |   result = yyparse();
      |            ^~~~~~~
```

---